### PR TITLE
Changes/fixes after running setup from README and running experiments

### DIFF
--- a/Experiment/scenario_runner.py
+++ b/Experiment/scenario_runner.py
@@ -17,6 +17,10 @@ parser.add_argument('-r', '--replan', action='store', type=int, dest='replan', h
 parser.add_argument('-t', '--planner_type', action='store', type=int, dest='planner_type', help='Sets the type of planner. 0: contingent, 1: overconfident, 2: underconfident.')
 parser.add_argument('-s', '--scenario', action='store', type=int, dest='scenario', help='Sets the scenario. 0: left turn, 1: overtake, 2: right turn')
 parser.add_argument('-l', '--location', action='store', type=int, dest='location', help='Sets location of the scenario, an integer from 0 to 3.')
+
+parser.add_argument('--video_name', type=str, dest='video_name', default='video')
+parser.add_argument('--max_episodes', type=int, dest='max_episodes', default=None)
+
 args = parser.parse_args()
 
 # configurations
@@ -99,6 +103,10 @@ class ScenarioRunner(object):
 
         # run this indefinitely
         while True:
+
+            if args.max_episodes and self.episode_num >= args.max_episodes:
+                print("Reached max episodes, exiting..")
+                raise KeyboardInterrupt
 
             if (PLANNER_TYPE == 2 and self.episode_num < 5):
                 self.check_episode_end()
@@ -605,14 +613,21 @@ class ScenarioRunner(object):
 
 def main():
     runner = ScenarioRunner()
+
+    if RECORDING:
+        image_folder = 'Visualize/camera_folder'
+        images = [img for img in sorted(os.listdir(image_folder)) if img.endswith(".jpg")]
+        # Wipe previous images
+        for im in images:
+            os.remove(os.path.join(image_folder,im))
+
     try:
         runner.start()
     finally:
 
         def exit_handler():
             if RECORDING:
-                image_folder = 'Visualize/camera_folder'
-                video_name = 'Visualize/video.avi'
+                video_name = 'Visualize/{}.avi'.format(args.video_name)
                 images = [img for img in sorted(os.listdir(image_folder)) if img.endswith(".jpg")]
                 frame = cv2.imread(os.path.join(image_folder, images[0]))
                 height, width, layers = frame.shape

--- a/Experiment/test.sh
+++ b/Experiment/test.sh
@@ -1,0 +1,73 @@
+CHECKPOINT=../Model/esp_train_results/2021-01/01-24-20-31-06_Left_Turn_Dataset_precog.bijection.social_convrnn.SocialConvRNN_/esp-model-668000
+MODEL=../Model/esp_train_results/2021-01/01-24-20-31-06_Left_Turn_Dataset_precog.bijection.social_convrnn.SocialConvRNN_
+
+# This is left turn with contingent planner at location 0.
+python scenario_runner.py \
+--enable-inference \
+--enable-control \
+--enable-recording \
+--checkpoint_path $CHECKPOINT \
+--model_path $MODEL \
+--replan 4 \
+--planner_type 0 \
+--scenario 0 \
+--location 0 \
+--video_name leftturn \
+--max_episodes 10
+
+# This is overtake with contingent planner at location 2
+python scenario_runner.py \
+--enable-inference \
+--enable-control \
+--enable-recording \
+--checkpoint_path $CHECKPOINT \
+--model_path $MODEL \
+--replan 4 \
+--planner_type 0 \
+--scenario 1 \
+--location 2 \
+--video_name overtake \
+--max_episodes 10
+
+# This right turn turn with contingent planner at location 3
+python scenario_runner.py \
+--enable-inference \
+--enable-control \
+--enable-recording \
+--checkpoint_path $CHECKPOINT \
+--model_path $MODEL \
+--replan 4 \
+--planner_type 0 \
+--scenario 2 \
+--location 3 \
+--video_name rightturn \
+--max_episodes 10
+
+# This is overtake with overconfident planner at location 2
+python scenario_runner.py \
+--enable-inference \
+--enable-control \
+--enable-recording \
+--checkpoint_path $CHECKPOINT \
+--model_path $MODEL \
+--replan 4 \
+--planner_type 1 \
+--scenario 1 \
+--location 2 \
+--video_name overtakeoverconfident \
+--max_episodes 3
+
+# Finally this is right turn with underconfident planner at location 0 The first 5 episodes will be run to collect data, and the 6 being the actual experiment.
+python scenario_runner.py \
+--enable-inference \
+--enable-control \
+--enable-recording \
+--checkpoint_path $CHECKPOINT \
+--model_path $MODEL \
+--replan 4 \
+--planner_type 2 \
+--scenario 2 \
+--location 0 \
+--video_name rightturnunderconfident \
+--max_episodes 6
+

--- a/precog_env.sh
+++ b/precog_env.sh
@@ -4,3 +4,6 @@ CURDIR=$(pwd)
 # Enable importing from source package.
 export PYTHONPATH=$PRECOGROOT:$PYTHONPATH;
 export PATH=$PRECOGROOT/scripts:$PATH
+
+# Make CARLA visible
+export PYTHONPATH=$CARLAROOT/PythonAPI/carla/dist/carla-0.9.8-py3.5-linux-x86_64.egg:$PYTHONPATH

--- a/readme.md
+++ b/readme.md
@@ -5,18 +5,38 @@
 1. Serve as the accompanying code for ICRA 2021 paper: Contingencies from Observations.
 2. A framework for running scenarios with Precog models in Carla.
 
+## Installing Carla
+
+This repository requires Carla 0.9.8. Please navigate to carla.org to download the correct packages, or do the following:
+```bash
+# Downloads hosted binaries
+wget http://carla-assets-internal.s3.amazonaws.com/Releases/Linux/CARLA_0.9.8.tar.gz
+
+# Unpack CARLA 0.9.8 download
+tar -xvzf CARLA_0.9.8.tar.gz -C /path/to/your/desired/carla/install
+```
+
+Once downloaded, make sure that `CARLAROOT` is set to point to your copy of CARLA:
+```bash
+export CARLAROOT=/path/to/your/carla/install
+```
+
+CARLAROOT should point to the basae directory, such that the output of `ls $CARLAROOT` shows the following files:
+```bash
+CarlaUE4     CHANGELOG   Engine  Import           LICENSE                        PythonAPI  Tools
+CarlaUE4.sh  Dockerfile  HDMaps  ImportAssets.sh  Manifest_DebugFiles_Linux.txt  README     VERSION
+```
+
 ## Setup
 
 ```bash
 conda create -n precog python=3.6.6
 conda activate precog
-source precog_env.sh # make sure to run this every time
+# make sure to source this every time after activating, and make sure $CARLAROOT is set beforehand
+source precog_env.sh
 pip install -r requirements.txt
 ```
-
-## Installing Carla
-
-This repository requires Carla 0.9.8. Please navigate to carla.org to install carla in the same conda environment.
+Note that `CARLAROOT` needs to be set and `source precog_env.sh` needs to be run every time you activate the conda env in a new window/shell.
 
 ## Running experiments with Precog model
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Once downloaded, make sure that `CARLAROOT` is set to point to your copy of CARL
 export CARLAROOT=/path/to/your/carla/install
 ```
 
-CARLAROOT should point to the basae directory, such that the output of `ls $CARLAROOT` shows the following files:
+CARLAROOT should point to the base directory, such that the output of `ls $CARLAROOT` shows the following files:
 ```bash
 CarlaUE4     CHANGELOG   Engine  Import           LICENSE                        PythonAPI  Tools
 CarlaUE4.sh  Dockerfile  HDMaps  ImportAssets.sh  Manifest_DebugFiles_Linux.txt  README     VERSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ backcall==0.1.0
 biwrap==0.1.6
 bleach==3.1.0
 cachetools==3.1.1
-carla==0.9.8
 certifi==2019.11.28
 chardet==3.0.4
 cloudpickle==1.1.1


### PR DESCRIPTION
- Deletes README that was sitting inside of visualize folder
- When you follow the install instructions, you end up getting an error when installing from requirements.txt because pip can't find `carla`. I think this is because you automatically exported requirements.txt, even though carla wasn't installed via pip? Instead, you can ask the user to set $CARLAROOT in the README, then in the script where you append to PYTHONPATH also append the PythonAPI from their CARLAROOT.
  - modified requirements.txt
  - modified precog_env.sh
- Changed scenario_runner.py to take two new args, max_episodes and video_name
  - I did this so that could automate the test experiments (since each takes >1hr and otherwise has to be manually exited on the right number of episodes)
  - Also modified scenario_runner.py to clear the images folder before running again (so that it can be run automatically back-to-back)
- Added a test script test.py that runs the test experiments (from slack) serially using the new args (max_episodes/video_name)
  - I'm not sure if we actually want this in the public release, but I think it would be good to have something similar that runs ALL the experiments from the paper (so that we can say "to reproduce the results from the paper run test.sh")
  - Also, this script makes it clear that a checkpoint is included in the repo itself and shows how to use it